### PR TITLE
Small fix on API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ BluetoothSerial
 
 Reads data from the buffer until it reaches a delimiter.
 
-  `read(options: BluetoothReadUntilOptions): Promise<BluetoothDataResult>`;
+  `readUntil(options: BluetoothReadUntilOptions): Promise<BluetoothDataResult>`;
 
 ### Description
 


### PR DESCRIPTION
This is just a small correction on API documentation that I noticed when reading it 